### PR TITLE
Don't pass a non-numeric weight to Weight

### DIFF
--- a/src/ValueObject/CartItem.php
+++ b/src/ValueObject/CartItem.php
@@ -72,7 +72,10 @@ class CartItem extends DataObject
             ->addTaxTableSelector((string)$data['tax_table_selector'])
             ->addDescription((string)$data['description']);
 
-        if (!empty($data['weight']['unit']) && !empty($data['weight']['value'])) {
+        if (!empty($data['weight']['unit'])
+            && !empty($data['weight']['value'])
+            && is_numeric($data['weight']['value'])
+        ) {
             $weight = new Weight($data['weight']['unit'], $data['weight']['value']);
             $item->addWeight($weight);
         }


### PR DESCRIPTION
There's no guarantee that the weight value returned from MultiSafepay's API is a float or numeric string.

If value is a number for a comma as a decimal separator (eg, `1,6 KG`), this will trigger a TypeError because Weight expects a float.

https://github.com/MultiSafepay/php-sdk/blob/acbefdef8a91480bd21ee1e5469d027086e52e21/src/ValueObject/Weight.php#L30

This PR prevents that from happening by checking that the value is numeric before initialising the Weight object.  But perhaps you should make sure that the MultiSafepay API always returns a float in the value field?