### PR TITLE
Make sure issuers is an array

### DIFF
--- a/src/Api/Issuers/IssuerListing.php
+++ b/src/Api/Issuers/IssuerListing.php
@@ -12,7 +12,7 @@ namespace MultiSafepay\Api\Issuers;
  */
 class IssuerListing
 {
-    private $issuers;
+    private $issuers = [];
 
     /**
      * Issuers constructor.


### PR DESCRIPTION
When data is empty, the `$this->issuers` property is null, not an array. This causes the Typehint to throw an error.

I suppose this is unexpected because it shouldn't be empty, but either the getIssuers() should be nullable typehint, or it should always be an array.