### PR TITLE
Feat: add affiliate to create order endpoint

### DIFF
--- a/.env.php.example
+++ b/.env.php.example
@@ -1,4 +1,5 @@
 <?php
 $variables = [
     'API_KEY' => '',
+    'PARTNER_ACCOUNT_ID' => '',
 ];

--- a/src/Api/Transactions/OrderRequest.php
+++ b/src/Api/Transactions/OrderRequest.php
@@ -8,6 +8,7 @@ namespace MultiSafepay\Api\Transactions;
 
 use MultiSafepay\Api\Base\RequestBody;
 use MultiSafepay\Api\Gateways\Gateway;
+use MultiSafepay\Api\Transactions\OrderRequest\Arguments\Affiliate;
 use MultiSafepay\Api\Transactions\OrderRequest\Arguments\CheckoutOptions;
 use MultiSafepay\Api\Transactions\OrderRequest\Arguments\CustomerDetails;
 use MultiSafepay\Api\Transactions\OrderRequest\Arguments\CustomInfo;
@@ -151,6 +152,11 @@ class OrderRequest extends RequestBody implements OrderRequestInterface
      * @var string
      */
     private $var3;
+
+    /**
+     * @var ?OrderRequest\Arguments\Affiliate
+     */
+    private $affiliate = null;
 
     /**
      * @param string $type
@@ -523,6 +529,20 @@ class OrderRequest extends RequestBody implements OrderRequestInterface
         return $this->var3;
     }
 
+    public function addAffiliate(?OrderRequest\Arguments\Affiliate $affiliate)
+    {
+        $this->affiliate = $affiliate;
+    }
+
+    /**
+     * @return Affiliate|null
+     */
+    public function getAffiliate(): ?OrderRequest\Arguments\Affiliate
+    {
+        return $this->affiliate;
+    }
+
+
     /**
      * @return array
      * phpcs:disable ObjectCalisthenics.Files.FunctionLength
@@ -554,6 +574,7 @@ class OrderRequest extends RequestBody implements OrderRequestInterface
             'var1' => $this->getVar1(),
             'var2' => $this->getVar2(),
             'var3' => $this->getVar3(),
+            'affiliate' => $this->affiliate ? $this->affiliate->getData() : null,
         ];
 
         $data = $this->removeNullRecursive(array_merge($data, $this->data));

--- a/src/Api/Transactions/OrderRequest.php
+++ b/src/Api/Transactions/OrderRequest.php
@@ -529,6 +529,10 @@ class OrderRequest extends RequestBody implements OrderRequestInterface
         return $this->var3;
     }
 
+    /**
+     * @param ?OrderRequest\Arguments\Affiliate $affiliate
+     * @return OrderRequest
+     */
     public function addAffiliate(?OrderRequest\Arguments\Affiliate $affiliate): OrderRequest
     {
         $this->affiliate = $affiliate;

--- a/src/Api/Transactions/OrderRequest.php
+++ b/src/Api/Transactions/OrderRequest.php
@@ -529,9 +529,10 @@ class OrderRequest extends RequestBody implements OrderRequestInterface
         return $this->var3;
     }
 
-    public function addAffiliate(?OrderRequest\Arguments\Affiliate $affiliate)
+    public function addAffiliate(?OrderRequest\Arguments\Affiliate $affiliate): OrderRequest
     {
         $this->affiliate = $affiliate;
+        return $this;
     }
 
     /**

--- a/src/Api/Transactions/OrderRequest/Arguments/Affiliate.php
+++ b/src/Api/Transactions/OrderRequest/Arguments/Affiliate.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright © MultiSafepay, Inc. All rights reserved.
+ * See DISCLAIMER.md for disclaimer details.
+ */
+
+namespace MultiSafepay\Api\Transactions\OrderRequest\Arguments;
+
+use MultiSafepay\Api\Transactions\OrderRequest\Arguments\Affiliate\SplitPayment;
+use MultiSafepay\Exception\InvalidArgumentException;
+
+/**
+ * Class Affiliate
+ * @package MultiSafepay\Api\Transactions\OrderRequest\Arguments
+ */
+class Affiliate
+{
+    /**
+     * @var SplitPayment[]
+     */
+    private $splitPayments;
+
+    /**
+     * @param SplitPayment[] $splitPayments
+     * @return Affiliate
+     */
+    public function addSplitPayments(array $splitPayments): Affiliate
+    {
+        $this->splitPayments = $splitPayments;
+        return $this;
+    }
+
+    /**
+     * Affiliate constructor.
+     * @param SplitPayment[] $splitPayments
+     */
+    public function __construct(array $splitPayments = [])
+    {
+        $this->splitPayments = $splitPayments;
+    }
+
+    /**
+     * @return array
+     * @throws InvalidArgumentException
+     */
+    public function getData(): array
+    {
+        return [
+            'split_payments' => array_map(function (SplitPayment $splitPayment) {
+                return $splitPayment->getData();
+            }, $this->splitPayments)
+        ];
+    }
+}

--- a/src/Api/Transactions/OrderRequest/Arguments/Affiliate.php
+++ b/src/Api/Transactions/OrderRequest/Arguments/Affiliate.php
@@ -48,7 +48,7 @@ class Affiliate
         return [
             'split_payments' => array_map(function (SplitPayment $splitPayment) {
                 return $splitPayment->getData();
-            }, $this->splitPayments)
+            }, $this->splitPayments),
         ];
     }
 }

--- a/src/Api/Transactions/OrderRequest/Arguments/Affiliate/SplitPayment.php
+++ b/src/Api/Transactions/OrderRequest/Arguments/Affiliate/SplitPayment.php
@@ -1,0 +1,142 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright © MultiSafepay, Inc. All rights reserved.
+ * See DISCLAIMER.md for disclaimer details.
+ */
+
+namespace MultiSafepay\Api\Transactions\OrderRequest\Arguments\Affiliate;
+
+use MultiSafepay\Api\Transactions\OrderRequest\Arguments\GatewayInfoInterface;
+use MultiSafepay\Exception\InvalidArgumentException;
+use MultiSafepay\ValueObject\Money;
+use MultiSafepay\ValueObject\Percentage;
+
+/**
+ * Class SplitPayment
+ * @package MultiSafepay\Api\Transactions\OrderRequest\Arguments\GatewayInfo
+ */
+class SplitPayment implements GatewayInfoInterface
+{
+    /**
+     * @var string
+     */
+    private $merchant;
+
+    /**
+     * @var ?string
+     */
+    private $description = null;
+
+    /**
+     * @var Money
+     */
+    private $fixed;
+
+    /**
+     * @var Percentage
+     */
+    private $percentage;
+
+    public function __construct(
+        ?string $merchant = null,
+        ?Money $fixed = null,
+        ?Percentage $percentage = null,
+        ?string $description = null
+    )
+    {
+        if($merchant !== null) {
+            $this->merchant = $merchant;
+        }
+
+        $this->description = $description;
+
+        if ($percentage !== null && $fixed !== null) {
+            throw new \InvalidArgumentException("You can only set either a fixed amount or a percentage, not both.");
+        }
+
+        if ($percentage !== null) {
+            $this->percentage = $percentage;
+        }
+        if($fixed !== null) {
+            $this->fixed = $fixed;
+        }
+    }
+
+    public function addMerchant(string $merchant): SplitPayment
+    {
+        $this->merchant = $merchant;
+        return $this;
+    }
+
+    public function addFixed(Money $fixedAmount): SplitPayment
+    {
+        $this->fixed = $fixedAmount;
+        return $this;
+    }
+
+    public function addPercentage(Percentage $percentage): SplitPayment
+    {
+        $this->percentage = $percentage;
+        return $this;
+    }
+
+    public function addDescription(?string $description): SplitPayment
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    /**
+     * @return array
+     * @throws InvalidArgumentException
+     */
+    public function getData(): array
+    {
+        $this->validate();
+
+        if(isset($this->percentage)){
+            return [
+                "merchant" => $this->merchant,
+                "percentage" => $this->percentage->getValue(),
+                "description" => $this->description,
+            ];
+        }
+
+        return [
+            "merchant" => $this->merchant,
+            "fixed" => $this->fixed->getAmountInCents(),
+            "description" => $this->description,
+        ];
+    }
+
+    public function validate(): void
+    {
+        if(isset($this->fixed) && isset($this->percentage)) {
+            throw new InvalidArgumentException("You can only set either a fixed amount or a percentage, not both.");
+        }
+
+        if(!isset($this->fixed) && !isset($this->percentage)) {
+            throw new InvalidArgumentException("You must set either a fixed amount or a percentage.");
+        }
+    }
+
+    public function getFixed(): Money
+    {
+        return $this->fixed;
+    }
+
+    public function getPercentage(): Percentage
+    {
+        return $this->percentage;
+    }
+
+    public function getMerchant(): string
+    {
+        return $this->merchant;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+}

--- a/src/Api/Transactions/OrderRequest/Arguments/Affiliate/SplitPayment.php
+++ b/src/Api/Transactions/OrderRequest/Arguments/Affiliate/SplitPayment.php
@@ -7,6 +7,7 @@
 namespace MultiSafepay\Api\Transactions\OrderRequest\Arguments\Affiliate;
 
 use MultiSafepay\Api\Transactions\OrderRequest\Arguments\GatewayInfoInterface;
+use MultiSafepay\Api\Transactions\OrderRequest\Arguments\TaxTable\TaxRate;
 use MultiSafepay\Exception\InvalidArgumentException;
 use MultiSafepay\ValueObject\Money;
 use MultiSafepay\ValueObject\Percentage;
@@ -37,14 +38,20 @@ class SplitPayment implements GatewayInfoInterface
      */
     private $percentage;
 
+    /**
+     * SplitPayment constructor.
+     * @param string|null $merchant
+     * @param Money|null $fixed
+     * @param Percentage|null $percentage
+     * @param string|null $description
+     */
     public function __construct(
         ?string $merchant = null,
         ?Money $fixed = null,
         ?Percentage $percentage = null,
         ?string $description = null
-    )
-    {
-        if($merchant !== null) {
+    ) {
+        if ($merchant !== null) {
             $this->merchant = $merchant;
         }
 
@@ -57,29 +64,46 @@ class SplitPayment implements GatewayInfoInterface
         if ($percentage !== null) {
             $this->percentage = $percentage;
         }
-        if($fixed !== null) {
+        if ($fixed !== null) {
             $this->fixed = $fixed;
         }
     }
 
+
+    /**
+     * @param string $merchant
+     * @return $this
+     */
     public function addMerchant(string $merchant): SplitPayment
     {
         $this->merchant = $merchant;
         return $this;
     }
 
+    /**
+     * @param Money $fixedAmount
+     * @return $this
+     */
     public function addFixed(Money $fixedAmount): SplitPayment
     {
         $this->fixed = $fixedAmount;
         return $this;
     }
 
+    /**
+     * @param Percentage $percentage
+     * @return $this
+     */
     public function addPercentage(Percentage $percentage): SplitPayment
     {
         $this->percentage = $percentage;
         return $this;
     }
 
+    /**
+     * @param string|null $description
+     * @return $this
+     */
     public function addDescription(?string $description): SplitPayment
     {
         $this->description = $description;
@@ -94,7 +118,7 @@ class SplitPayment implements GatewayInfoInterface
     {
         $this->validate();
 
-        if(isset($this->percentage)){
+        if (isset($this->percentage)) {
             return [
                 "merchant" => $this->merchant,
                 "percentage" => $this->percentage->getValue(),
@@ -109,32 +133,48 @@ class SplitPayment implements GatewayInfoInterface
         ];
     }
 
+    /**
+     * @return void
+     * @throws InvalidArgumentException
+     */
     public function validate(): void
     {
-        if(isset($this->fixed) && isset($this->percentage)) {
+        if (isset($this->fixed) && isset($this->percentage)) {
             throw new InvalidArgumentException("You can only set either a fixed amount or a percentage, not both.");
         }
 
-        if(!isset($this->fixed) && !isset($this->percentage)) {
+        if (!isset($this->fixed) && !isset($this->percentage)) {
             throw new InvalidArgumentException("You must set either a fixed amount or a percentage.");
         }
     }
 
+    /**
+     * @return Money
+     */
     public function getFixed(): Money
     {
         return $this->fixed;
     }
 
+    /**
+     * @return Percentage
+     */
     public function getPercentage(): Percentage
     {
         return $this->percentage;
     }
 
+    /**
+     * @return string
+     */
     public function getMerchant(): string
     {
         return $this->merchant;
     }
 
+    /**
+     * @return string|null
+     */
     public function getDescription(): ?string
     {
         return $this->description;

--- a/src/Api/Transactions/OrderRequest/Arguments/Affiliate/SplitPayment.php
+++ b/src/Api/Transactions/OrderRequest/Arguments/Affiliate/SplitPayment.php
@@ -104,7 +104,7 @@ class SplitPayment implements GatewayInfoInterface
 
         return [
             "merchant" => $this->merchant,
-            "fixed" => $this->fixed->getAmountInCents(),
+            "fixed" => $this->fixed ? (int)round($this->fixed->getAmount()) : null,
             "description" => $this->description,
         ];
     }

--- a/src/ValueObject/Percentage.php
+++ b/src/ValueObject/Percentage.php
@@ -44,6 +44,9 @@ class Percentage
         return $this->percentage;
     }
 
+    /**
+     * @return string
+     */
     public function __toString(): string
     {
         return (string) $this->percentage . '%';

--- a/src/ValueObject/Percentage.php
+++ b/src/ValueObject/Percentage.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright © MultiSafepay, Inc. All rights reserved.
+ * See DISCLAIMER.md for disclaimer details.
+ */
+
+namespace MultiSafepay\ValueObject;
+
+/**
+ * Class Percentage
+ * @package MultiSafepay\ValueObject
+ */
+class Percentage
+{
+    /**
+     * @var float
+     */
+    private $percentage;
+
+    /**
+     * Percentage constructor.
+     *
+     * @param float $percentage
+     * percentage value 10% = 10
+     */
+    public function __construct(float $percentage)
+    {
+        if ($percentage < 0) {
+            throw new \InvalidArgumentException('Percentage value must be greater than or equal to 0');
+        }
+
+        if ($percentage > 100) {
+            throw new \InvalidArgumentException('Percentage value must be less than or equal to 100');
+        }
+
+        $this->percentage = $percentage;
+    }
+
+    /**
+     * @return float
+     */
+    public function getValue(): float
+    {
+        return $this->percentage;
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->percentage . '%';
+    }
+}

--- a/tests/Fixtures/OrderRequest/Arguments/AffiliateFixture.php
+++ b/tests/Fixtures/OrderRequest/Arguments/AffiliateFixture.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+/**
+ * Copyright © MultiSafepay, Inc. All rights reserved.
+ * See DISCLAIMER.md for disclaimer details.
+ */
+
+namespace MultiSafepay\Tests\Fixtures\OrderRequest\Arguments;
+
+use MultiSafepay\Api\Transactions\OrderRequest\Arguments\Affiliate;
+use MultiSafepay\ValueObject\Money;
+
+/**
+ * Trait AffiliateFixture
+ * @package MultiSafepay\Tests\Fixtures\OrderRequest\Arguments
+ */
+trait AffiliateFixture
+{
+    /**
+     * @return Affiliate
+     */
+    public function createAffiliateFixture(): Affiliate
+    {
+        $splitPayment = new Affiliate\SplitPayment();
+        $splitPayment->addMerchant('00000001');
+        $splitPayment->addFixed(new Money(10));
+
+        return new Affiliate([$splitPayment]);
+    }
+}

--- a/tests/Fixtures/OrderRequest/Arguments/AffiliateFixture.php
+++ b/tests/Fixtures/OrderRequest/Arguments/AffiliateFixture.php
@@ -18,11 +18,12 @@ trait AffiliateFixture
     /**
      * @return Affiliate
      */
-    public function createAffiliateFixture(): Affiliate
+    public function createAffiliateFixture(?string $merchantId = '00000001'): Affiliate
     {
         $splitPayment = new Affiliate\SplitPayment();
-        $splitPayment->addMerchant('00000001');
+        $splitPayment->addMerchant($merchantId);
         $splitPayment->addFixed(new Money(10));
+        $splitPayment->addDescription('test description');
 
         return new Affiliate([$splitPayment]);
     }

--- a/tests/Functional/AbstractTestCase.php
+++ b/tests/Functional/AbstractTestCase.php
@@ -46,4 +46,12 @@ abstract class AbstractTestCase extends TestCase
 
         return new Sdk($apiKey, false);
     }
+
+    protected function getPartnerAccountId(): string
+    {
+        $accountId = getenv('PARTNER_ACCOUNT_ID');
+        $this->assertNotEmpty($accountId);
+
+        return $accountId;
+    }
 }

--- a/tests/Functional/AbstractTestCase.php
+++ b/tests/Functional/AbstractTestCase.php
@@ -47,6 +47,9 @@ abstract class AbstractTestCase extends TestCase
         return new Sdk($apiKey, false);
     }
 
+    /**
+     * @return string
+     */
     protected function getPartnerAccountId(): string
     {
         $accountId = getenv('PARTNER_ACCOUNT_ID');

--- a/tests/Functional/Api/Transactions/CreateAffiliateOrderTest.php
+++ b/tests/Functional/Api/Transactions/CreateAffiliateOrderTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+namespace Functional\Api\Transactions;
+
+use MultiSafepay\Api\Transactions\OrderRequest;
+use MultiSafepay\Exception\ApiException;
+use MultiSafepay\Tests\Fixtures\Api\Gateways\GatewayFixture;
+use MultiSafepay\Tests\Fixtures\OrderRequest\Arguments\AffiliateFixture;
+use MultiSafepay\Tests\Fixtures\OrderRequest\Arguments\CustomerDetailsFixture;
+use MultiSafepay\Tests\Fixtures\OrderRequest\Arguments\DescriptionFixture;
+use MultiSafepay\Tests\Fixtures\OrderRequest\Arguments\IdealGatewayInfoFixture;
+use MultiSafepay\Tests\Fixtures\OrderRequest\Arguments\PaymentOptionsFixture;
+use MultiSafepay\Tests\Fixtures\OrderRequest\Arguments\PluginDetailsFixture;
+use MultiSafepay\Tests\Fixtures\OrderRequest\Arguments\SecondChanceFixture;
+use MultiSafepay\Tests\Fixtures\OrderRequest\Arguments\ShoppingCartFixture;
+use MultiSafepay\Tests\Fixtures\OrderRequest\Arguments\TaxTableFixture;
+use MultiSafepay\Tests\Fixtures\OrderRequest\GenericOrderRequestFixture;
+use MultiSafepay\Tests\Fixtures\ValueObject\AddressFixture;
+use MultiSafepay\Tests\Fixtures\ValueObject\CountryFixture;
+use MultiSafepay\Tests\Fixtures\ValueObject\PhoneNumberFixture;
+use MultiSafepay\Tests\Functional\AbstractTestCase;
+use MultiSafepay\ValueObject\Money;
+use Psr\Http\Client\ClientExceptionInterface;
+
+/**
+ * Class CreateAffiliateOrderTest
+ * @package MultiSafepay\Tests\Functional\Api\Transactions
+ */
+class CreateAffiliateOrderTest extends AbstractTestCase
+{
+    use GenericOrderRequestFixture;
+    use CustomerDetailsFixture;
+    use PaymentOptionsFixture;
+    use AddressFixture;
+    use ShoppingCartFixture;
+    use TaxTableFixture;
+    use DescriptionFixture;
+    use SecondChanceFixture;
+    use PluginDetailsFixture;
+    use IdealGatewayInfoFixture;
+    use PhoneNumberFixture;
+    use CountryFixture;
+    use AffiliateFixture;
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testCreateAffiliateOrder()
+    {
+        $orderRequest = $this->createOrderRequest();
+
+        try {
+            $response = $this->getClient()->createPostRequest('json/orders', $orderRequest);
+        } catch (ApiException $apiException) {
+            $this->assertTrue(false, $apiException->getDetails());
+            return;
+        }
+
+        $data = $response->getResponseData();
+        $this->assertIsNumeric($data['order_id']);
+        $this->assertNotEmpty($data['payment_url']);
+    }
+
+    /**
+     * @return OrderRequest
+     */
+    private function createOrderRequest(): OrderRequest
+    {
+        return $this->createGenericOrderRequestFixture()
+            ->addType('redirect')
+            ->addMoney(new Money(200, 'EUR'))
+            ->addGatewayCode(GatewayFixture::IDEAL)
+            ->addGatewayInfo($this->createIdealGatewayInfoFixture())
+            ->addPaymentOptions($this->createPaymentOptionsFixture())
+            ->addAffiliate($this->createAffiliateFixture($this->getPartnerAccountId()));
+    }
+}

--- a/tests/Unit/Api/Transactions/OrderRequest/Arguments/AffiliateTest.php
+++ b/tests/Unit/Api/Transactions/OrderRequest/Arguments/AffiliateTest.php
@@ -21,7 +21,7 @@ class AffiliateTest extends TestCase
 
         $affiliate = new Affiliate();
         $affiliate->addSplitPayments([
-            $splitPayment
+            $splitPayment,
         ]);
 
         $data = $affiliate->getData();

--- a/tests/Unit/Api/Transactions/OrderRequest/Arguments/AffiliateTest.php
+++ b/tests/Unit/Api/Transactions/OrderRequest/Arguments/AffiliateTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+namespace MultiSafepay\Tests\Unit\Api\Transactions\OrderRequest\Arguments;
+
+use MultiSafepay\Api\Transactions\OrderRequest\Arguments\Affiliate;
+use MultiSafepay\Api\Transactions\OrderRequest\Arguments\TaxTable;
+use MultiSafepay\Exception\InvalidArgumentException;
+use MultiSafepay\ValueObject\Money;
+use PHPUnit\Framework\TestCase;
+
+class AffiliateTest extends TestCase
+{
+    /**
+     * @covers \MultiSafepay\Api\Transactions\OrderRequest\Arguments\Affiliate::getData
+     * @covers \MultiSafepay\Api\Transactions\OrderRequest\Arguments\Affiliate::addSplitPayments
+     */
+    public function testGetData()
+    {
+        $splitPayment = new Affiliate\SplitPayment();
+        $splitPayment->addMerchant('merchant');
+        $splitPayment->addFixed(new Money(10));
+
+        $affiliate = new Affiliate();
+        $affiliate->addSplitPayments([
+            $splitPayment
+        ]);
+
+        $data = $affiliate->getData();
+        $this->assertSame(1, count($data['split_payments']));
+        $this->assertSame([
+            'merchant' => 'merchant',
+            'fixed' => (float) 1000,
+            'description' => null,
+        ], $data['split_payments'][0]);
+    }
+
+    /**
+     * @covers \MultiSafepay\Api\Transactions\OrderRequest\Arguments\Affiliate::getData
+     */
+    public function testUsingConstructors()
+    {
+        $splitPayment = new Affiliate\SplitPayment(
+            'merchant',
+            new Money(10)
+        );
+
+        $affiliate = new Affiliate([$splitPayment]);
+
+        $data = $affiliate->getData();
+        $this->assertSame(1, count($data['split_payments']));
+        $this->assertSame([
+            'merchant' => 'merchant',
+            'fixed' => (float) 1000,
+            'description' => null,
+        ], $data['split_payments'][0]);
+    }
+}

--- a/tests/Unit/Api/Transactions/OrderRequest/Arguments/AffiliateTest.php
+++ b/tests/Unit/Api/Transactions/OrderRequest/Arguments/AffiliateTest.php
@@ -28,7 +28,7 @@ class AffiliateTest extends TestCase
         $this->assertSame(1, count($data['split_payments']));
         $this->assertSame([
             'merchant' => 'merchant',
-            'fixed' => (float) 1000,
+            'fixed' => 10,
             'description' => null,
         ], $data['split_payments'][0]);
     }
@@ -49,7 +49,7 @@ class AffiliateTest extends TestCase
         $this->assertSame(1, count($data['split_payments']));
         $this->assertSame([
             'merchant' => 'merchant',
-            'fixed' => (float) 1000,
+            'fixed' => 10,
             'description' => null,
         ], $data['split_payments'][0]);
     }

--- a/tests/Unit/Api/Transactions/OrderRequest/Arguments/TaxTable/SplitPaymentTest.php
+++ b/tests/Unit/Api/Transactions/OrderRequest/Arguments/TaxTable/SplitPaymentTest.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types=1);
+namespace MultiSafepay\Tests\Unit\Api\Transactions\OrderRequest\Arguments\TaxTable;
+
+use MultiSafepay\Api\Transactions\OrderRequest\Arguments\Affiliate\SplitPayment;
+use MultiSafepay\Api\Transactions\OrderRequest\Arguments\TaxTable\TaxRate;
+use MultiSafepay\Exception\InvalidArgumentException;
+use MultiSafepay\ValueObject\Customer\Country;
+use MultiSafepay\ValueObject\Money;
+use MultiSafepay\ValueObject\Percentage;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class SplitPaymentTest
+ * @package MultiSafepay\Tests\Unit\Api\Transactions\OrderRequest\Arguments
+ */
+class SplitPaymentTest extends TestCase
+{
+    /**
+     * Test setting fixed amount works
+     */
+    public function testAddingFixAmount()
+    {
+        $splitPayment = new SplitPayment();
+        $splitPayment->addFixed(new Money(10));
+        $this->assertEquals(1000, $splitPayment->getFixed()->getAmountInCents());
+    }
+
+    /**
+     * Test setting a percentage works
+     */
+    public function testAddPercentage()
+    {
+        $splitPayment = new SplitPayment();
+        $splitPayment->addPercentage(new Percentage(10));
+        $this->assertEquals(10, $splitPayment->getPercentage()->getValue());
+    }
+
+    /**
+     * Test setting both a percentage and a fixed amount fails validation
+     */
+    public function testSettingPercentageAndFixedAmountFailsValidation()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $splitPayment = new SplitPayment();
+        $splitPayment->addFixed(new Money(10));
+        $splitPayment->addPercentage(new Percentage(10));
+
+        $splitPayment->validate();
+    }
+
+    /**
+     * Test setting a merchant works
+     */
+    public function testAddMerchant()
+    {
+        $splitPayment = new SplitPayment();
+        $splitPayment->addMerchant('123123');
+        $this->assertEquals('123123', $splitPayment->getMerchant());
+    }
+
+    /**
+     * Test setting a description works
+     */
+    public function testSettingsDescriptionWorks()
+    {
+        $splitPayment = new SplitPayment();
+        $splitPayment->addDescription('application fee');
+        $this->assertEquals('application fee', $splitPayment->getDescription());
+    }
+
+    /**
+     * Test get data for fixed amount
+     */
+    public function testGetDataForFixedAmount()
+    {
+        $splitPayment = new SplitPayment();
+        $splitPayment->addFixed(new Money(10));
+        $splitPayment->addDescription('application fee');
+        $splitPayment->addMerchant('123123');
+        $this->assertEquals([
+            'fixed' => 1000,
+            'description' => 'application fee',
+            'merchant' => '123123'
+        ], $splitPayment->getData());
+    }
+
+    /**
+     * Test get data for percentage
+     */
+    public function testGetDataForPercentage()
+    {
+        $splitPayment = new SplitPayment();
+        $splitPayment->addPercentage(new Percentage(10));
+        $splitPayment->addDescription('application fee');
+        $splitPayment->addMerchant('123123');
+        $this->assertEquals([
+            'percentage' => 10,
+            'description' => 'application fee',
+            'merchant' => '123123'
+        ], $splitPayment->getData());
+    }
+
+    /**
+     * Test fails when no percentage and no fixed amount is set
+     */
+    public function testItFailsWhenNoPercentageAndNoFixedAmountIsSet()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $splitPayment = new SplitPayment();
+        $splitPayment->addDescription('application fee');
+        $splitPayment->addMerchant('123123');
+        $splitPayment->validate();
+    }
+
+}

--- a/tests/Unit/Api/Transactions/OrderRequest/Arguments/TaxTable/SplitPaymentTest.php
+++ b/tests/Unit/Api/Transactions/OrderRequest/Arguments/TaxTable/SplitPaymentTest.php
@@ -80,7 +80,7 @@ class SplitPaymentTest extends TestCase
         $this->assertEquals([
             'fixed' => 10,
             'description' => 'application fee',
-            'merchant' => '123123'
+            'merchant' => '123123',
         ], $splitPayment->getData());
     }
 
@@ -96,7 +96,7 @@ class SplitPaymentTest extends TestCase
         $this->assertEquals([
             'percentage' => 10,
             'description' => 'application fee',
-            'merchant' => '123123'
+            'merchant' => '123123',
         ], $splitPayment->getData());
     }
 
@@ -111,5 +111,4 @@ class SplitPaymentTest extends TestCase
         $splitPayment->addMerchant('123123');
         $splitPayment->validate();
     }
-
 }

--- a/tests/Unit/Api/Transactions/OrderRequest/Arguments/TaxTable/SplitPaymentTest.php
+++ b/tests/Unit/Api/Transactions/OrderRequest/Arguments/TaxTable/SplitPaymentTest.php
@@ -78,7 +78,7 @@ class SplitPaymentTest extends TestCase
         $splitPayment->addDescription('application fee');
         $splitPayment->addMerchant('123123');
         $this->assertEquals([
-            'fixed' => 1000,
+            'fixed' => 10,
             'description' => 'application fee',
             'merchant' => '123123'
         ], $splitPayment->getData());

--- a/tests/Unit/Api/Transactions/OrderRequestTest.php
+++ b/tests/Unit/Api/Transactions/OrderRequestTest.php
@@ -5,6 +5,7 @@ use MultiSafepay\Api\Transactions\OrderRequest;
 use MultiSafepay\Api\Transactions\OrderRequest\Arguments\ShoppingCart\Item as ShoppingCartItem;
 use MultiSafepay\Exception\InvalidArgumentException;
 use MultiSafepay\Tests\Fixtures\Api\Gateways\GatewayFixture;
+use MultiSafepay\Tests\Fixtures\OrderRequest\Arguments\AffiliateFixture;
 use MultiSafepay\Tests\Fixtures\OrderRequest\Arguments\CustomerDetailsFixture;
 use MultiSafepay\Tests\Fixtures\OrderRequest\Arguments\DescriptionFixture;
 use MultiSafepay\Tests\Fixtures\OrderRequest\Arguments\GoogleAnalyticsFixture;
@@ -45,6 +46,7 @@ class OrderRequestTest extends TestCase
     use PhoneNumberFixture;
     use ShoppingCartFixture;
     use OrderRequestWithoutPluginDetails;
+    use AffiliateFixture;
 
     /**
      * Test if regular creation of an order works
@@ -144,7 +146,7 @@ class OrderRequestTest extends TestCase
         $this->assertArrayHasKey('terminal_id', $data['gateway_info']);
         $this->assertEquals('terminal-id', $data['gateway_info']['terminal_id']);
     }
-    
+
     /**
      * Test if we can add a customer object, only setting up the reference, and get the Order Request
      */
@@ -195,5 +197,18 @@ class OrderRequestTest extends TestCase
         $this->assertEquals('Multi', $orderRequest->getVar1());
         $this->assertEquals('Safe', $orderRequest->getVar2());
         $this->assertEquals('Pay', $orderRequest->getVar3());
+    }
+
+    /**
+     * Test if we can get affiliate data, within an order request
+     */
+    public function testOrderWithAffiliate()
+    {
+        $orderRequest = $this->createIdealOrderRedirectRequestFixture();
+        $orderRequest->addAffiliate($this->createAffiliateFixture());
+        $data = $orderRequest->getData();
+
+        $this->assertArrayHasKey('affiliate', $data);
+        $this->assertArrayHasKey('split_payments', $data['affiliate']);
     }
 }

--- a/tests/Unit/ValueObject/PercentageTest.php
+++ b/tests/Unit/ValueObject/PercentageTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+namespace MultiSafepay\Tests\Unit\ValueObject;
+
+use MultiSafepay\ValueObject\Money;
+use MultiSafepay\ValueObject\Percentage;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class PercentageTest
+ * @package MultiSafepay\Tests\Unit\ValueObject
+ */
+class PercentageTest extends TestCase
+{
+    /**
+     * Test constructing with normal value
+     */
+    public function testNormalUsage()
+    {
+        $percentage = new Percentage(42);
+        $this->assertEquals(42, $percentage->getValue());
+    }
+
+    /**
+     * Test constructing with normal value
+     */
+    public function testNullPercent()
+    {
+        $percentage = new Percentage(0);
+        $this->assertEquals(0, $percentage->getValue());
+    }
+
+    /**
+     * Test constructing with normal value
+     */
+    public function testHundredPercent()
+    {
+        $percentage = new Percentage(100);
+        $this->assertEquals(100, $percentage->getValue());
+    }
+
+    /**
+     * Test it fails when constructing with negative value
+     */
+    public function testNegativeNumbers()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Percentage(-1);
+    }
+
+    /**
+     * Test it fails when constructing with value over 100
+     */
+    public function testUpperBound()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Percentage(101);
+    }
+}


### PR DESCRIPTION
This PR adds the ability to add Affiliate data to the create order endpoint in order to create split payments.

It requires to add PARTNER_ACCOUNT_ID to the .env.php in order to make the Functional test work.