### PR TITLE
Use correct case for emandate property in Gateway Account

### DIFF
--- a/src/Api/Transactions/OrderRequest/Arguments/GatewayInfo/Account.php
+++ b/src/Api/Transactions/OrderRequest/Arguments/GatewayInfo/Account.php
@@ -34,7 +34,7 @@ class Account implements GatewayInfoInterface
     /**
      * @var string
      */
-    private $emanDate;
+    private $emandate;
 
     /**
      * @param IbanNumber $accountId
@@ -92,9 +92,9 @@ class Account implements GatewayInfoInterface
      * @param string $emanDate
      * @return Account
      */
-    public function addEmanDate(string $emanDate): Account
+    public function addEmandate(string $emandate): Account
     {
-        $this->emanDate = $emanDate;
+        $this->emandate = $emandate;
         return $this;
     }
 
@@ -107,7 +107,7 @@ class Account implements GatewayInfoInterface
             'account_id' => $this->accountId ? $this->accountId->get() : null,
             'account_holder_iban' => $this->accountHolderIban ? $this->accountHolderIban->get() : null,
             'account_holder_name' => $this->accountHolderName,
-            'emandate' => $this->emanDate,
+            'emandate' => $this->emandate,
         ];
     }
 }

--- a/tests/Unit/Api/Transactions/OrderRequest/Arguments/GatewayInfo/AccountTest.php
+++ b/tests/Unit/Api/Transactions/OrderRequest/Arguments/GatewayInfo/AccountTest.php
@@ -13,7 +13,7 @@ class AccountTest extends TestCase
      * @covers \MultiSafepay\Api\Transactions\OrderRequest\Arguments\GatewayInfo\Account::addAccountId
      * @covers \MultiSafepay\Api\Transactions\OrderRequest\Arguments\GatewayInfo\Account::addAccountHolderIban
      * @covers \MultiSafepay\Api\Transactions\OrderRequest\Arguments\GatewayInfo\Account::addAccountHolderName
-     * @covers \MultiSafepay\Api\Transactions\OrderRequest\Arguments\GatewayInfo\Account::addEmanDate
+     * @covers \MultiSafepay\Api\Transactions\OrderRequest\Arguments\GatewayInfo\Account::addEmandate
      */
     public function testGetData()
     {
@@ -37,7 +37,6 @@ class AccountTest extends TestCase
      *
      * @covers \MultiSafepay\Api\Transactions\OrderRequest\Arguments\GatewayInfo\Account::addAccountIdAsString
      * @covers \MultiSafepay\Api\Transactions\OrderRequest\Arguments\GatewayInfo\Account::addAccountHolderIbanAsString
-     * @covers \MultiSafepay\Api\Transactions\OrderRequest\Arguments\GatewayInfo\Account::addEmanDate
      */
     public function testSettingValueObjectsUsingAsStringMethods()
     {

--- a/tests/Unit/Api/Transactions/OrderRequest/Arguments/GatewayInfo/AccountTest.php
+++ b/tests/Unit/Api/Transactions/OrderRequest/Arguments/GatewayInfo/AccountTest.php
@@ -24,12 +24,12 @@ class AccountTest extends TestCase
         $account->addAccountId($iban);
         $account->addAccountHolderIban($iban);
         $account->addAccountHolderName('John Doe');
-        $account->addEmanDate('1 januari 1970');
+        $account->addEmandate('id_xxxx');
         $data = $account->getData();
         $this->assertSame($iban->get(), $data['account_id']);
         $this->assertSame($iban->get(), $data['account_holder_iban']);
         $this->assertSame('John Doe', $data['account_holder_name']);
-        $this->assertSame('1 januari 1970', $data['emandate']);
+        $this->assertSame('id_xxxx', $data['emandate']);
     }
 
     /**


### PR DESCRIPTION
While setting up a transactions gateway data I got confused by the `addEmanDate()` method name and added the date of the mandate to that field.
However that field refers to the property emandate as per the [docs](https://docs.multisafepay.com/reference/createorder)

```
emandate
string
For SEPA Direct Debit direct orders (required), the unique emandate identifier (for your own administration).
```

I have edited the class to reflect the correct property name.
Due to the private visibility of the property, and PHP's case-insensitive function names this should not cause any problems in backward compatibility.